### PR TITLE
Fix lock - do not power solenoid for 5min

### DIFF
--- a/Lock.c
+++ b/Lock.c
@@ -15,12 +15,11 @@ void Lock()
     int n;
     for (n = 0; n < 2000; n++)
     {
-        LOCK_TRIS = 0; // Output
-        LOCK_PIN = 1;
+        LOCK_PIN = 0; // Lock is non-powered
     }
 }
 
 void Unlock()
 {
-    LOCK_PIN = 0;
+    LOCK_PIN = 1; // Lock is powered
 }


### PR DESCRIPTION
Burnt myself on very hot solenoid -> therefore, we decided we needed to do something about this. We moved the solenoid onto the door and power it only when unlocking or closing door, as it is active-unlocked